### PR TITLE
Macro stdatomic.h functions we use to Interlocked* for Windows.

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -4,7 +4,6 @@
  * as explained at http://creativecommons.org/publicdomain/zero/1.0/
  */
 
-#include <stdatomic.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>


### PR DESCRIPTION
Add macros from stdatmic.h functions to Interlocked*, as MSVC does
no support stdatomic.h as its not a full C compiler.

Change-Id: Ia7b79f00bdca8ee4d956eb86dc514b25d4fc11e9