### PR TITLE
Use same build C build flags as rest of Couchbase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(HDR_SOVERSION ${HDR_SOVERSION_CURRENT})
 ENABLE_TESTING()
 
 if(UNIX)
-    set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes -Wpedantic -D_GNU_SOURCE -std=gnu89")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes -Wpedantic -D_GNU_SOURCE")
     set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     set(CMAKE_C_FLAGS_RELEASE "-O3 -g")
 endif()


### PR DESCRIPTION
Use the same C build flags when building HdrHistogram_c as the rest of
kv_engine. So that if thread sanitizer or address sanitizer is enabled
HdrHistogram_c will also have the correct compiler flags set to enable
the same sanitization as the rest of binaries being built.

Change-Id: I41e9300480e2c99213e572766893ac52b5ac672e