### PR TITLE
Fix int64_t* to atomic_int_least64_t* compiler warning

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -346,7 +346,7 @@ int hdr_init(
         int significant_figures,
         struct hdr_histogram** result)
 {
-    int64_t* counts;
+    atomic_int_least64_t* counts;
     struct hdr_histogram_bucket_config cfg;
     struct hdr_histogram* histogram;
 


### PR DESCRIPTION
Change-Id: I37e26231bccaa4ee50fea51b4fdb1e357c65bffb