### PR TITLE
Cache align struct hdr_histogram to prevent cache line contention

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(HDR_SOVERSION ${HDR_SOVERSION_CURRENT})
 ENABLE_TESTING()
 
 if(UNIX)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes -Wpedantic -D_GNU_SOURCE")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas -Wextra -Wshadow -Winit-self -Wmissing-prototypes -Wpedantic -std=c11 -D_GNU_SOURCE")
     set(CMAKE_C_FLAGS_DEBUG "-O0 -g")
     set(CMAKE_C_FLAGS_RELEASE "-O3 -g")
 endif()


### PR DESCRIPTION
Add new hdr_aligned_calloc and hdr_aligned free, to make sure
the memory allocation of struct hdr_histogram and counts are
always cache lined in memory.

Also pad out struct hdr_histogram so it fits over three cache lines.
Also move write only once read meany, struct members so they are in
the same cache line. To help reduce cache contention on x86
platforms where cache lines are 64 bytes.

Change-Id: Iaa027ae662206b08182fb065b3f4a08ceb94404e