### PR TITLE
Fix infinite loop bug in update_min_max on Windows

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -78,6 +78,19 @@ static void counts_inc_normalised(
     atomic_fetch_add_explicit(&h->total_count, value, memory_order_relaxed);
 }
 
+#ifdef _MSC_VER
+_Bool atomic_compare_exchange(volatile atomic_int_least64_t* obj,
+                              int64_t* expected,
+                              int64_t desired) {
+    if (InterlockedCompareExchange64(obj, desired, *expected) == *expected) {
+        return true;
+    } else {
+        *expected = atomic_load_explicit(obj, memory_order_relaxed);
+        return false;
+    }
+}
+#endif
+
 static void update_min_max(struct hdr_histogram* h, int64_t value) {
     if (value > 0) {
         int64_t observedMin =

--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -52,10 +52,13 @@
         typedef volatile int64_t atomic_int_least64_t;
         #define memory_order_relaxed 0
 
+        _Bool atomic_compare_exchange(volatile atomic_int_least64_t *obj,
+                                            int64_t* expected, int64_t desired);
+
         #define atomic_load_explicit(loadAdd, memory_order) (*loadAdd)
         #define atomic_compare_exchange_weak_explicit( \
                 obj, expected, desired, succ, fail)    \
-            (InterlockedCompareExchange64(obj, desired, *expected) == *expected)
+            atomic_compare_exchange(obj, expected, desired)
         #define atomic_fetch_add_explicit(obj, arg, memory_order) \
             InterlockedExchangeAdd64(obj, arg)
         #define atomic_store_explicit(obj, arg, memory_order) \


### PR DESCRIPTION
On Windows make sure we re-observe the values of observedMin and
observedMax, if InterlockedCompareExchange64 fails to set a value.
As unlike atomic_compare_exchange_weak_explicit,
InterlockedCompareExchange64 does not do this for us. This meant
that if the value was of ->min_value or ->max_value was changed
between the observed and InterlockedCompareExchange64 we would enter
into an infinite loop as we never updated the observed value.

Change-Id: Ic8b76bea1dc35d187376b3952ecb5ab258e874c9