### PR TITLE
Fix -Wunused-result warning due to posix_memalign()

### DIFF
--- a/src/hdr_histogram.c
+++ b/src/hdr_histogram.c
@@ -370,7 +370,10 @@ void* hdr_aligned_calloc(size_t num, size_t size) {
 #ifdef _MSC_VER
     memPtr = _aligned_malloc(num * size, 128);
 #else
-    posix_memalign(&memPtr, 128, num * size);
+    // posix_memalign() returns 0 on success, otherwise return NULL ptr
+    if(posix_memalign(&memPtr, 128, num * size) != 0) {
+        return NULL;
+    }
 #endif
     if(memPtr) {
         memset(memPtr, 0, num * size);


### PR DESCRIPTION
Fix compiler warning -Wunused-result, due to the return value of
posix_memaling() not being used. The return value posix_memalign() is a
status code, for which 0 is success. Thus, if the value is not 0 we
have failed to allocate a memory to the pointer. So we should
return a NULL pointer to the caller.