### PR TITLE
MB-40967: Change hdr_iter to 64 bit

### DIFF
--- a/src/hdr_histogram.h
+++ b/src/hdr_histogram.h
@@ -396,7 +396,7 @@ struct hdr_iter
     /** raw index into the counts array */
     int32_t counts_index;
     /** snapshot of the length at the time the iterator is created */
-    int32_t total_count;
+    int64_t total_count;
     /** value directly from array for the current counts_index */
     int64_t count;
     /** sum of all of the counts up to and including the count at this index */


### PR DESCRIPTION
hdr_iter takes the total_count of the histogram (h) at construction.
The count used in the histogram is a 64 bit count. When we have more
than std::numeric_limits<int32_t>::max() counts in the histogram the
total_count field of the hdr_iter will underflow when we create the
iterator and various >0 checks will check in and prevent iteration of
the histogram.

Correct this by using a 64 bit type total_count field in hdr_iter.

Change-Id: I09d81dc75def8538852d7fc2307e98e7c821bdfe