### PR TITLE
Fix compile warning from -Wstrict-prototypes

### DIFF
--- a/src/hdr_thread.c
+++ b/src/hdr_thread.c
@@ -47,7 +47,7 @@ void hdr_mutex_unlock(struct hdr_mutex* mutex)
     LeaveCriticalSection((CRITICAL_SECTION*)(mutex->_critical_section));
 }
 
-void hdr_yield()
+void hdr_yield(void)
 {
     Sleep(0);
 }
@@ -88,7 +88,7 @@ void hdr_mutex_unlock(struct hdr_mutex* mutex)
     pthread_mutex_unlock(&mutex->_mutex);
 }
 
-void hdr_yield()
+void hdr_yield(void)
 {
     sched_yield();
 }


### PR DESCRIPTION
HdrHistogram_c/src/hdr_thread.c:91:15: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes] void hdr_yield()
              ^
               void
1 warning generated.